### PR TITLE
[SID-1157] Expose the SlashID SDK config through docusaurus config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.1",
+  "version": "0.2.2",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docusaurus-theme-slashid/README.md
+++ b/packages/docusaurus-theme-slashid/README.md
@@ -31,7 +31,10 @@ Key Features:
 Theme:
 
 ```bash
-yarn add @slashid/react @slashid/docusaurus-theme-slashid
+# npm
+npm install @slashid/slashid @slashid/react @slashid/docusaurus-theme-slashid
+# yarn
+yarn add @slashid/slashid @slashid/react @slashid/docusaurus-theme-slashid
 ```
 
 ## Configuring `docusaurus.config.js`
@@ -46,18 +49,19 @@ Add the following to `docusaurus.config.js` to start using the theme:
 
    themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-    ({
+     ({
       ...
       slashID: {
         orgID: "your slash id org id",
-        oidcClientID: "optional OIDC client ID";
-        oidcProvider: "optional OIDC provider name";
-        forceLogin: "boolean flag to determine if login is required";
-        baseURL?: "optional base API URL for the SDK, defaults to the sandbox environment";
-        sdkURL?: "optional base SDK page URL for the SDK, defaults to the sandbox environment";
+        oidcClientID: "optional OIDC client ID",
+        oidcProvider: "optional OIDC provider name",
+        forceLogin: "boolean flag to determine if login is required",
+        baseURL: "optional base API URL for the SDK, defaults to the sandbox environment",
+        sdkURL: "optional base SDK page URL for the SDK, defaults to the sandbox environment",
       },
 
-  themes: ["@slashid/docusaurus-theme-slashid"],
+    themes: ["@slashid/docusaurus-theme-slashid"],
+  }
 }
 ```
 
@@ -81,12 +85,14 @@ Also please remember to include the login form styles:
 
 The `docusaurus-theme-slashid` theme can be configured with the following options:
 
-| Name                   | Type      | Default | Description                  |
-| ---------------------- | --------- | ------- | ---------------------------- |
-| `slashID.orgID`        | `string`  | `null`  | The SlashID organization ID. |
-| `slashID.oidcClientID` | `string`  | `null`  | OIDC client ID.              |
-| `slashID.oidcProvider` | `string`  | `null`  | OIDC provider name.          |
-| `slashID.forceLogin`   | `boolean` | `false` | Make login required.         |
+| Name                   | Type      | Default | Description                                                         |
+| ---------------------- | --------- | ------- | ------------------------------------------------------------------- |
+| `slashID.orgID`        | `string`  | `null`  | The SlashID organization ID.                                        |
+| `slashID.oidcClientID` | `string`  | `null`  | OIDC client ID.                                                     |
+| `slashID.oidcProvider` | `string`  | `null`  | OIDC provider name.                                                 |
+| `slashID.forceLogin`   | `boolean` | `false` | Make login required.                                                |
+| `slashID.baseURL`      | `boolean` | `false` | Base API URL for the SDK, defaults to the sandbox environment.      |
+| `slashID.sdkURL`       | `boolean` | `false` | Base SDK page URL for the SDK, defaults to the sandbox environment. |
 
 ## Support
 

--- a/packages/docusaurus-theme-slashid/README.md
+++ b/packages/docusaurus-theme-slashid/README.md
@@ -49,7 +49,12 @@ Add the following to `docusaurus.config.js` to start using the theme:
     ({
       ...
       slashID: {
-        orgID: "your slash id org id"
+        orgID: "your slash id org id",
+        oidcClientID: "optional OIDC client ID";
+        oidcProvider: "optional OIDC provider name";
+        forceLogin: "boolean flag to determine if login is required";
+        baseURL?: "optional base API URL for the SDK, defaults to the sandbox environment";
+        sdkURL?: "optional base SDK page URL for the SDK, defaults to the sandbox environment";
       },
 
   themes: ["@slashid/docusaurus-theme-slashid"],

--- a/packages/docusaurus-theme-slashid/package.json
+++ b/packages/docusaurus-theme-slashid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slashid/docusaurus-theme-slashid",
   "description": "SlashID theme for Docusaurus.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "keywords": [
     "login",

--- a/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
@@ -63,7 +63,11 @@ export default function Root({ children }: any) {
   const options = themeConfig.slashID;
 
   return (
-    <SlashIDProvider oid={options?.orgID!}>
+    <SlashIDProvider
+      oid={options?.orgID!}
+      baseApiUrl={options?.baseURL}
+      sdkUrl={options?.sdkURL}
+    >
       <AuthProvider>
         <AuthCheck
           forceLogin={options?.forceLogin}

--- a/packages/docusaurus-theme-slashid/src/types.ts
+++ b/packages/docusaurus-theme-slashid/src/types.ts
@@ -16,5 +16,7 @@ export interface ThemeConfig {
     oidcClientID?: string;
     oidcProvider?: OAuthProvider;
     forceLogin?: boolean;
+    baseURL?: string;
+    sdkURL?: string;
   };
 }


### PR DESCRIPTION
Added the base API & SDK URL options to the docusaurus config so they could be overriden. Fixes #10 