### PR TITLE
[SID-1164] Use the production env by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.3 (Aug 7, 2023)
+
+High level enhancements
+
+- switched to the `production` as the default environment
+
 ## 0.2.1 (Jul 20, 2023)
 
 High level enhancements

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.2",
+  "version": "0.2.3",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docusaurus-theme-slashid/README.md
+++ b/packages/docusaurus-theme-slashid/README.md
@@ -56,8 +56,8 @@ Add the following to `docusaurus.config.js` to start using the theme:
         oidcClientID: "optional OIDC client ID",
         oidcProvider: "optional OIDC provider name",
         forceLogin: "boolean flag to determine if login is required",
-        baseURL: "optional base API URL for the SDK, defaults to the sandbox environment",
-        sdkURL: "optional base SDK page URL for the SDK, defaults to the sandbox environment",
+        baseURL: "optional base API URL for the SDK, defaults to the production environment",
+        sdkURL: "optional base SDK page URL for the SDK, defaults to the production environment",
       },
 
     themes: ["@slashid/docusaurus-theme-slashid"],
@@ -85,14 +85,14 @@ Also please remember to include the login form styles:
 
 The `docusaurus-theme-slashid` theme can be configured with the following options:
 
-| Name                   | Type      | Default | Description                                                         |
-| ---------------------- | --------- | ------- | ------------------------------------------------------------------- |
-| `slashID.orgID`        | `string`  | `null`  | The SlashID organization ID.                                        |
-| `slashID.oidcClientID` | `string`  | `null`  | OIDC client ID.                                                     |
-| `slashID.oidcProvider` | `string`  | `null`  | OIDC provider name.                                                 |
-| `slashID.forceLogin`   | `boolean` | `false` | Make login required.                                                |
-| `slashID.baseURL`      | `boolean` | `false` | Base API URL for the SDK, defaults to the sandbox environment.      |
-| `slashID.sdkURL`       | `boolean` | `false` | Base SDK page URL for the SDK, defaults to the sandbox environment. |
+| Name                   | Type      | Default | Description                                                            |
+| ---------------------- | --------- | ------- | ---------------------------------------------------------------------- |
+| `slashID.orgID`        | `string`  | `null`  | The SlashID organization ID.                                           |
+| `slashID.oidcClientID` | `string`  | `null`  | OIDC client ID.                                                        |
+| `slashID.oidcProvider` | `string`  | `null`  | OIDC provider name.                                                    |
+| `slashID.forceLogin`   | `boolean` | `false` | Make login required.                                                   |
+| `slashID.baseURL`      | `boolean` | `false` | Base API URL for the SDK, defaults to the production environment.      |
+| `slashID.sdkURL`       | `boolean` | `false` | Base SDK page URL for the SDK, defaults to the production environment. |
 
 ## Support
 

--- a/packages/docusaurus-theme-slashid/package.json
+++ b/packages/docusaurus-theme-slashid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slashid/docusaurus-theme-slashid",
   "description": "SlashID theme for Docusaurus.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "MIT",
   "keywords": [
     "login",

--- a/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
@@ -65,8 +65,8 @@ export default function Root({ children }: any) {
   return (
     <SlashIDProvider
       oid={options?.orgID!}
-      baseApiUrl={options?.baseURL}
-      sdkUrl={options?.sdkURL}
+      baseApiUrl={options?.baseURL || "https://api.slashid.com"}
+      sdkUrl={options?.sdkURL || "https://cdn.slashid.com/sdk.html"}
     >
       <AuthProvider>
         <AuthCheck


### PR DESCRIPTION
Since the self serve accounts get created in the `production` environment, this plugin will default to that environment unless a config override is set.