### PR TITLE
[SID-1548] Configuration extension: share the configuration interface with React SDK

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,10 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": true
     }
+  },
+  "[javascript][typescript][typescriptreact]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.0 (Feb 12, 2024)
+
+High level enhancements
+
+- legacy config params `slashID.oidcClientID` and `slashID.oidcProvider` will be deprecated in the next major version
+- logo, text and authentications methods can now be customised using the `slashID.formConfiguration` option
+
 ## 0.3.3 (Feb 5, 2024)
 
 High level enhancements

--- a/apps/demo/docusaurus.config.js
+++ b/apps/demo/docusaurus.config.js
@@ -63,12 +63,19 @@ const config = {
   themes: ["@slashid/docusaurus-theme-slashid"],
 
   themeConfig:
-    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+    /** @type {import('@slashid/docusaurus-theme-slashid').ThemeConfig} */
     ({
       slashID: {
         // orgID used for code examples
         orgID: "a6b69fd8-cd7a-f516-2705-d531d709acf8",
         forceLogin: false,
+        formConfiguration: {
+          factors: [{ method: "email_link" }],
+          logo: "https://logodix.com/logo/1931244.jpg",
+          text: {
+            "initial.title": "/id Docusaurus login theme",
+          },
+        },
         // uses the production API
         baseURL: "https://api.slashid.com",
         sdkURL: "https://cdn.slashid.com/sdk.html",

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "build": "docusaurus build",
@@ -30,7 +30,7 @@
     "@docusaurus/core": "^2.4.0",
     "@docusaurus/preset-classic": "^2.4.0",
     "@mdx-js/react": "^1.6.22",
-    "@slashid/docusaurus-theme-slashid": "^0.3.3",
+    "@slashid/docusaurus-theme-slashid": "^0.4.0",
     "@slashid/react": "^1.18.0",
     "@slashid/slashid": "^3.18.0",
     "clsx": "^1.2.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.3",
+  "version": "0.4.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docusaurus-theme-slashid/README.md
+++ b/packages/docusaurus-theme-slashid/README.md
@@ -32,9 +32,9 @@ Theme:
 
 ```bash
 # npm
-npm install @slashid/slashid @slashid/react @slashid/docusaurus-theme-slashid
+npm install @slashid/docusaurus-theme-slashid
 # yarn
-yarn add @slashid/slashid @slashid/react @slashid/docusaurus-theme-slashid
+yarn add @slashid/docusaurus-theme-slashid
 ```
 
 ## Configuring `docusaurus.config.js`

--- a/packages/docusaurus-theme-slashid/README.md
+++ b/packages/docusaurus-theme-slashid/README.md
@@ -19,7 +19,7 @@ SlashID theme to add authentication to Docusaurus.
 
 ## Overview
 
-The `@slashid/docusaurus-theme-slashid` package extends Docusaurus to add authentication to docusaurus. The theme can be combined with [docusaurus openapi docs](https://github.com/slashid/docusaurus-slashid-login) to preload API keys and API parameters directly through SlashID attributes.
+The `@slashid/docusaurus-theme-slashid` package extends [@docusaurus/preset-classic](https://docusaurus.io/docs/using-plugins#docusauruspreset-classic) to add authentication to websites generated using Docusaurus.
 
 Key Features:
 
@@ -53,8 +53,6 @@ Add the following to `docusaurus.config.js` to start using the theme:
       ...
       slashID: {
         orgID: "your slash id org id",
-        oidcClientID: "optional OIDC client ID",
-        oidcProvider: "optional OIDC provider name",
         forceLogin: "boolean flag to determine if login is required",
         baseURL: "optional base API URL for the SDK, defaults to the production environment",
         sdkURL: "optional base SDK page URL for the SDK, defaults to the production environment",
@@ -64,6 +62,16 @@ Add the following to `docusaurus.config.js` to start using the theme:
             groups: ["optional list of groups that can access the path"],
           }
         ],
+        formConfiguration: {
+          // authentication methods presented to end users
+          factors: [{ method: "email_link" }],
+          // logo you want to display on the login form
+          logo: "<YOUR_LOGO_URL>",
+          // customisable text content
+          text: {
+            "initial.title": "/id Docusaurus login theme",
+          },
+        },
       },
 
     themes: ["@slashid/docusaurus-theme-slashid"],
@@ -87,19 +95,24 @@ Also please remember to include the login form styles:
 
 ```
 
+The configuration options are explained in the following section.
+
 ## Theme Configuration Options
 
 The `docusaurus-theme-slashid` theme can be configured with the following options:
 
-| Name                   | Type            | Default     | Description                                                            |
-| ---------------------- | --------------- | ----------- | ---------------------------------------------------------------------- |
-| `slashID.orgID`        | `string`        | `null`      | The SlashID organization ID.                                           |
-| `slashID.oidcClientID` | `string`        | `null`      | OIDC client ID.                                                        |
-| `slashID.oidcProvider` | `string`        | `null`      | OIDC provider name.                                                    |
-| `slashID.forceLogin`   | `boolean`       | `false`     | Make login required.                                                   |
-| `slashID.baseURL`      | `boolean`       | `false`     | Base API URL for the SDK, defaults to the production environment.      |
-| `slashID.sdkURL`       | `boolean`       | `false`     | Base SDK page URL for the SDK, defaults to the production environment. |
-| `slashID.privatePaths` | `PrivatePath[]` | `undefined` | Optional set of private paths.                                         |
+| Name                        | Type            | Default     | Description                                                            |
+| --------------------------- | --------------- | ----------- | ---------------------------------------------------------------------- |
+| `slashID.orgID`             | `string`        | `null`      | The SlashID organization ID.                                           |
+| `slashID.forceLogin`        | `boolean`       | `false`     | Make login required.                                                   |
+| `slashID.baseURL`           | `boolean`       | `false`     | Base API URL for the SDK, defaults to the production environment.      |
+| `slashID.sdkURL`            | `boolean`       | `false`     | Base SDK page URL for the SDK, defaults to the production environment. |
+| `slashID.privatePaths`      | `PrivatePath[]` | `undefined` | Optional set of private paths.                                         |
+| `slashID.formConfiguration` | `object`        | `undefined` | Optional form configuration                                            |
+
+### Form configuration
+
+As mentioned in the above table, it is possible to customise the login form by passing in the `slashID.formConfiguration` object. The values sent here are the same ones that can be passed to the [`<ConfigurationProvider>`](https://developer.slashid.dev/docs/access/react-sdk/reference/components/react-sdk-reference-configurationprovider#props). This lets you specify the authentication methods displayed to your users, customise the UI by swapping the text constants and the logo.
 
 ### Interface: `PrivatePath`
 

--- a/packages/docusaurus-theme-slashid/README.md
+++ b/packages/docusaurus-theme-slashid/README.md
@@ -26,6 +26,10 @@ Key Features:
 - **Compatible:** Supports Magic Links, Passkeys, OTP via sms and SSO.
 - **Personalization:** Allows to load per-user configuration data into docusaurus.
 
+## Documentation
+
+For detailed setup & usage instructions, please check the [documentation in our developer portal](https://developer.slashid.dev/docs/access/integrations/docusaurus-login). Below you'll find a short summary of steps required to get started quickly.
+
 ## Installation
 
 Theme:
@@ -39,7 +43,51 @@ yarn add @slashid/docusaurus-theme-slashid
 
 ## Configuring `docusaurus.config.js`
 
-Add the following to `docusaurus.config.js` to start using the theme:
+After installing the app and [signing up with SlashID](https://console.slashid.dev/signup) go through the following steps in order.
+
+### Adding the styles
+
+Include the login form styles:
+
+```js
+// under presets
+
+{
+    theme: {
+        customCss: [
+            require.resolve("@slashid/react/style.css"), // add this line
+        ],
+    }
+}
+```
+
+### Adding the Auth button
+
+You can render a button in the navbar to allow customers to log in. To do so, add this item to the `navbar.items` field in the `themeConfig`:
+
+```js
+{
+  // ...
+  themeConfig: ({
+    // ...
+    navbar: {
+      // ...
+      items: [
+        // ...
+        {
+          type: "custom-AuthButton",
+          position: "right",
+          className: "button button--secondary button--lg",
+        },
+      ],
+    },
+  });
+}
+```
+
+### Configure the theme
+
+Add the following to the `themeConfig` in `docusaurus.config.js`:
 
 ```js
 // docusaurus.config.js
@@ -77,22 +125,6 @@ Add the following to `docusaurus.config.js` to start using the theme:
     themes: ["@slashid/docusaurus-theme-slashid"],
   }
 }
-```
-
-Also please remember to include the login form styles:
-
-```js
-// under presets
-
-{
-    theme: {
-        customCss: [
-            require.resolve("./src/css/custom.scss"), // existing custom css
-            require.resolve("@slashid/react/style.css"), // add this line
-        ],
-    }
-}
-
 ```
 
 The configuration options are explained in the following section.

--- a/packages/docusaurus-theme-slashid/package.json
+++ b/packages/docusaurus-theme-slashid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashid/docusaurus-theme-slashid",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "SlashID theme for Docusaurus.",
   "keywords": [
     "login",

--- a/packages/docusaurus-theme-slashid/package.json
+++ b/packages/docusaurus-theme-slashid/package.json
@@ -29,8 +29,8 @@
     "watch": "concurrently --names \"lib,lib-next,tsc\" --kill-others \"yarn babel:lib --watch\" \"yarn babel:lib-next --watch\" \"yarn tsc --watch\""
   },
   "dependencies": {
-    "@slashid/react": "^1.18.0",
-    "@slashid/slashid": "^3.18.0",
+    "@slashid/react": "^1.18.1",
+    "@slashid/slashid": "^3.18.2",
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "glob-to-regexp": "^0.4.1",

--- a/packages/docusaurus-theme-slashid/src/domain.ts
+++ b/packages/docusaurus-theme-slashid/src/domain.ts
@@ -5,11 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
+import type { ContextType } from "react";
+
 import type {
   PropSidebarItem,
   PropSidebarItemHtml,
   PropSidebarItemCategory,
 } from "@docusaurus/plugin-content-docs";
+import { ConfigurationContext } from "@slashid/react";
 import type { User } from "@slashid/slashid";
 import { OAuthProvider } from "@slashid/slashid";
 import globToRegexp from "glob-to-regexp";
@@ -19,16 +22,34 @@ export interface PrivatePath {
   groups?: string[];
 }
 export interface ThemeConfig {
-  slashID: {
-    orgID: string;
-    oidcClientID?: string;
-    oidcProvider?: OAuthProvider;
-    forceLogin?: boolean;
-    baseURL?: string;
-    sdkURL?: string;
-    privatePaths?: PrivatePath[];
-    privateRedirectPath?: string;
-  };
+  slashID: LegacyThemeConfig | NewThemeConfig;
+}
+
+export interface LegacyThemeConfig {
+  orgID: string;
+  // @deprecated use formConfiguration instead
+  oidcClientID?: string;
+  // @deprecated use formConfiguration instead
+  oidcProvider?: OAuthProvider;
+  forceLogin?: boolean;
+  baseURL?: string;
+  sdkURL?: string;
+  privatePaths?: PrivatePath[];
+  privateRedirectPath?: string;
+}
+
+export type SlashIDConfigurationProviderConfig = Partial<
+  ContextType<typeof ConfigurationContext>
+>;
+
+export interface NewThemeConfig {
+  orgID: string;
+  forceLogin?: boolean;
+  baseURL?: string;
+  sdkURL?: string;
+  privatePaths?: PrivatePath[];
+  privateRedirectPath?: string;
+  formConfiguration?: SlashIDConfigurationProviderConfig;
 }
 
 export type SlashIDProps = {

--- a/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
@@ -37,6 +37,7 @@ const AuthCheck: React.FC<AuthCheckProps> = ({
   const { user } = useSlashID();
   const { showLogin } = useContext(AuthContext);
   const isBrowser = useIsBrowser();
+  const options = useSlashIDConfig();
 
   // TODO figure out where the reference to window is
   if (!isBrowser) {
@@ -48,12 +49,12 @@ const AuthCheck: React.FC<AuthCheckProps> = ({
     return user ? (
       <>{children}</>
     ) : (
-      <SlashID oidcClientID={oidcClientID} oidcProvider={oidcProvider} />
+      <SlashID configuration={options.formConfiguration!} />
     );
   }
 
   return showLogin ? (
-    <SlashID oidcClientID={oidcClientID} oidcProvider={oidcProvider} />
+    <SlashID configuration={options.formConfiguration!} />
   ) : (
     <>{children}</>
   );
@@ -73,13 +74,7 @@ export default function Root({ children }: any) {
       <ServerThemeRoot>
         <AuthProvider>
           <SlashIDLoaded>
-            <AuthCheck
-              forceLogin={options.forceLogin}
-              oidcClientID={options.oidcClientID}
-              oidcProvider={options.oidcProvider}
-            >
-              {children}
-            </AuthCheck>
+            <AuthCheck forceLogin={options.forceLogin}>{children}</AuthCheck>
           </SlashIDLoaded>
         </AuthProvider>
       </ServerThemeRoot>

--- a/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
@@ -14,7 +14,6 @@ import {
   useSlashID,
   ServerThemeRoot,
 } from "@slashid/react";
-import { OAuthProvider } from "@slashid/slashid";
 
 import "./reset.css";
 import "./globals.css";
@@ -23,17 +22,9 @@ import { AuthContext, AuthProvider } from "./auth-context";
 import { SlashID } from "./slashid";
 
 interface AuthCheckProps {
-  forceLogin?: boolean;
-  oidcClientID?: string;
-  oidcProvider?: OAuthProvider;
   children: React.ReactNode;
 }
-const AuthCheck: React.FC<AuthCheckProps> = ({
-  forceLogin = false,
-  oidcClientID,
-  oidcProvider,
-  children,
-}) => {
+const AuthCheck: React.FC<AuthCheckProps> = ({ children }) => {
   const { user } = useSlashID();
   const { showLogin } = useContext(AuthContext);
   const isBrowser = useIsBrowser();
@@ -45,7 +36,7 @@ const AuthCheck: React.FC<AuthCheckProps> = ({
   }
 
   // if login is configured to be mandatory
-  if (forceLogin) {
+  if (options.forceLogin) {
     return user ? (
       <>{children}</>
     ) : (
@@ -74,7 +65,7 @@ export default function Root({ children }: any) {
       <ServerThemeRoot>
         <AuthProvider>
           <SlashIDLoaded>
-            <AuthCheck forceLogin={options.forceLogin}>{children}</AuthCheck>
+            <AuthCheck>{children}</AuthCheck>
           </SlashIDLoaded>
         </AuthProvider>
       </ServerThemeRoot>

--- a/packages/docusaurus-theme-slashid/src/theme/Root/slashid.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/Root/slashid.tsx
@@ -9,20 +9,20 @@ import React, { useCallback } from "react";
 
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import { ConfigurationProvider, Form } from "@slashid/react";
-import { Factor, OAuthProvider, User } from "@slashid/slashid";
+import { User } from "@slashid/slashid";
 
+import { SlashIDConfigurationProviderConfig } from "../../domain";
 import { AuthContext } from "./auth-context";
 import styles from "./slashid.module.css";
 
 type Props = {
-  oidcClientID?: string;
-  oidcProvider?: OAuthProvider;
+  configuration: SlashIDConfigurationProviderConfig;
 };
 
 // SlashID docs depend on this
 export const STORAGE_KEY = "MY_USER_TOKEN";
 
-export function SlashID({ oidcClientID, oidcProvider }: Props) {
+export function SlashID({ configuration }: Props) {
   const { setShowLogin } = React.useContext(AuthContext);
   const isBrowser = useIsBrowser();
   const handleSuccess = useCallback(
@@ -35,27 +35,8 @@ export function SlashID({ oidcClientID, oidcProvider }: Props) {
     [isBrowser, setShowLogin]
   );
 
-  let factors: Factor[] = [
-    {
-      method: "email_link",
-    },
-  ];
-
-  const hasOidc = oidcClientID && oidcProvider;
-  if (hasOidc) {
-    const oidcFactor: Factor = {
-      method: "oidc",
-      options: {
-        client_id: oidcClientID,
-        provider: oidcProvider,
-        ux_mode: "popup",
-      },
-    };
-    factors = [...factors, oidcFactor];
-  }
-
   return (
-    <ConfigurationProvider factors={factors} storeLastHandle>
+    <ConfigurationProvider factors={configuration.factors} storeLastHandle>
       <main className={styles.slashid}>
         <Form className={styles.form} onSuccess={handleSuccess} />
       </main>

--- a/packages/docusaurus-theme-slashid/src/theme/Root/slashid.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/Root/slashid.tsx
@@ -36,7 +36,13 @@ export function SlashID({ configuration }: Props) {
   );
 
   return (
-    <ConfigurationProvider factors={configuration.factors} storeLastHandle>
+    <ConfigurationProvider
+      factors={configuration.factors}
+      logo={configuration.logo}
+      storeLastHandle={configuration.storeLastHandle ?? true}
+      text={configuration.text}
+      defaultCountryCode={configuration.defaultCountryCode ?? "US"}
+    >
       <main className={styles.slashid}>
         <Form className={styles.form} onSuccess={handleSuccess} />
       </main>

--- a/packages/docusaurus-theme-slashid/src/theme/hooks/useSlashIDConfig.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/hooks/useSlashIDConfig.tsx
@@ -9,25 +9,92 @@ import { useMemo } from "react";
 
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
-import { ThemeConfig, convertGlobToRegex } from "../../domain";
+import {
+  LegacyThemeConfig,
+  NewThemeConfig,
+  ThemeConfig,
+  convertGlobToRegex,
+} from "../../domain";
 
-const DEFAULT_CONFIG = {
+function isLegacyConfig(
+  config: NewThemeConfig | LegacyThemeConfig
+): config is LegacyThemeConfig {
+  if (
+    config.hasOwnProperty("oidcClientID") &&
+    config.hasOwnProperty("oidcProvider")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+const DEFAULT_CONFIG: NewThemeConfig = {
   orgID: "",
   forceLogin: false,
   baseURL: "https://api.slashid.com",
   sdkURL: "https://cdn.slashid.com/sdk.html",
   privateRedirectPath: "/",
+  formConfiguration: {
+    storeLastHandle: true,
+    factors: [
+      {
+        method: "email_link",
+      },
+    ],
+  },
 };
 
-export const useSlashIDConfig = (): ThemeConfig["slashID"] => {
+export const useSlashIDConfig = (): NewThemeConfig => {
   const { siteConfig } = useDocusaurusContext();
   const { slashID } = siteConfig.themeConfig as unknown as ThemeConfig;
 
   const safeOptions = useMemo(() => {
-    const optionsWithDefaults: ThemeConfig["slashID"] = {
+    // handle the legacy theme config
+    if (
+      isLegacyConfig(slashID) &&
+      slashID.oidcClientID &&
+      slashID.oidcProvider
+    ) {
+      const {
+        orgID,
+        forceLogin,
+        baseURL,
+        sdkURL,
+        privatePaths,
+        privateRedirectPath,
+      } = slashID;
+      const options: NewThemeConfig = {
+        orgID,
+        forceLogin,
+        baseURL,
+        sdkURL,
+        privatePaths,
+        privateRedirectPath,
+        formConfiguration: {
+          factors: [
+            {
+              method: "email_link",
+            },
+            {
+              method: "oidc",
+              options: {
+                client_id: slashID.oidcClientID,
+                provider: slashID.oidcProvider,
+                ux_mode: "popup",
+              },
+            },
+          ],
+        },
+      };
+      return convertGlobToRegex({ ...DEFAULT_CONFIG, ...options });
+    }
+
+    const optionsWithDefaults: NewThemeConfig = {
       ...DEFAULT_CONFIG,
       ...slashID,
     };
+
     return convertGlobToRegex(optionsWithDefaults);
   }, [slashID]);
 

--- a/packages/docusaurus-theme-slashid/src/theme/hooks/useSlashIDConfig.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/hooks/useSlashIDConfig.tsx
@@ -98,5 +98,7 @@ export const useSlashIDConfig = (): NewThemeConfig => {
     return convertGlobToRegex(optionsWithDefaults);
   }, [slashID]);
 
+  console.log({ safeOptions });
+
   return safeOptions;
 };

--- a/packages/docusaurus-theme-slashid/src/theme/hooks/useSlashIDConfig.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/hooks/useSlashIDConfig.tsx
@@ -98,7 +98,5 @@ export const useSlashIDConfig = (): NewThemeConfig => {
     return convertGlobToRegex(optionsWithDefaults);
   }, [slashID]);
 
-  console.log({ safeOptions });
-
   return safeOptions;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3696,6 +3696,24 @@
     country-flag-emoji-polyfill "^0.1.4"
     country-list-with-dial-code-and-flag "^3.0.2"
 
+"@slashid/react@^1.18.1":
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/@slashid/react/-/react-1.18.1.tgz#b1b8f0db3abec333a5cd74ee6d97811cd50b8fce"
+  integrity sha512-Y6MIOc6K8xMFozjGsWPJFEPC9y0Yj2UHEUNU6B9V93W0v6jPJb9BCEPnC+19oqTpCrk+UHSEH4F/hV+BjzxqWg==
+  dependencies:
+    "@radix-ui/react-accordion" "^1.1.2"
+    "@radix-ui/react-dialog" "^1.0.4"
+    "@radix-ui/react-select" "^1.1.2"
+    "@radix-ui/react-switch" "^1.0.3"
+    "@radix-ui/react-tabs" "^1.0.1"
+    "@vanilla-extract/css" "^1.9.2"
+    "@vanilla-extract/dynamic" "^2.0.3"
+    "@vanilla-extract/recipes" "^0.3.0"
+    "@vanilla-extract/sprinkles" "^1.5.1"
+    compress.js "^1.2.2"
+    country-flag-emoji-polyfill "^0.1.4"
+    country-list-with-dial-code-and-flag "^3.0.2"
+
 "@slashid/slashid@^3.12.0":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@slashid/slashid/-/slashid-3.12.0.tgz#9b8fe2e0900eedaa1c375c840550aa866818ec9f"
@@ -3717,6 +3735,23 @@
   version "3.18.0"
   resolved "https://registry.yarnpkg.com/@slashid/slashid/-/slashid-3.18.0.tgz#ead3593425e643645fa595b1faaa7c802ef3bfe7"
   integrity sha512-pPZ5eZvXkHuu5u58UuS2cCULH9Xi1BHQ/pzHKVE/tNE2SxjlBfGl3VcZaL4g/qMN6hV4mei779s0ieivsAWjHQ==
+  dependencies:
+    "@changesets/cli" "^2.26.2"
+    "@types/uuid" "8.3.4"
+    changeset "^0.2.6"
+    docdash "^1.2.0"
+    jwt-decode "^3.1.2"
+    mitt "^3.0.0"
+    qrcode "^1.5.1"
+    querystring-es3 "^0.2.1"
+    regenerator-runtime "^0.13.9"
+    url "^0.11.0"
+    uuid "8.3.2"
+
+"@slashid/slashid@^3.18.2":
+  version "3.18.2"
+  resolved "https://registry.yarnpkg.com/@slashid/slashid/-/slashid-3.18.2.tgz#dc610ae2104bfd0fb5e528b42ad4852b50eef75d"
+  integrity sha512-h0t6IBZaRV/Jkl5x+F2/6QqxicdbAo9jllet0ketACeMIbMOoYWPCsRQq0XoK4M3ZAznhb2FBfg0JNHOKogQQg==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@types/uuid" "8.3.4"


### PR DESCRIPTION
Login theme will now accept an additional configuration parameter - `formConfiguration`. This optional parameter accepts an object of the same shape as the props of the [ConfigurationProvider](https://developer.slashid.dev/docs/access/react-sdk/reference/components/react-sdk-reference-configurationprovider#props).

This will add extra flexibility and remove friction between the underlying React SDK and the docusaurus theme.

## Testing
I published a beta version `@slashid/docusaurus-theme-slashid@0.4.0-beta.0` to facilitate testing, so the most relevant test steps would be these:
- create a new Docusaurus website using docusaurus v2 (v3 is not supported yet)
- follow the Readme to set the theme up (but please make sure to install `@slashid/docusaurus-theme-slashid@0.4.0-beta.0`)
- check the docs and play with the `formConfiguration` option to see if various combinations still work

Legacy configuration API has the extra fields to set up OIDC but they are no longer documented:
```
slashID.oidcClientID
slashID.oidcProvider
```

We still support them so that the theme does not break someones website if they update to the next minor version. If you pass the legacy options, the new `formConfiguration` option will be ignored.