### PR TITLE
[SID-1577] Restrict access to custom pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0 (Feb 26, 2024)
+
+High level enhancements
+
+- added the `slashID.uxMode` config option to define behaviour when accessing private pages
+
 ## 0.4.0 (Feb 12, 2024)
 
 High level enhancements

--- a/apps/demo/docusaurus.config.js
+++ b/apps/demo/docusaurus.config.js
@@ -69,6 +69,8 @@ const config = {
         // orgID used for code examples
         orgID: "a6b69fd8-cd7a-f516-2705-d531d709acf8",
         forceLogin: false,
+        // UX when a non-logged in user tries to access a private page (render form in a modal or redirect to the page specified by privateRedirectPath)
+        uxMode: "modal",
         formConfiguration: {
           factors: [{ method: "email_link" }],
           logo: "https://logodix.com/logo/1931244.jpg",

--- a/apps/demo/docusaurus.config.js
+++ b/apps/demo/docusaurus.config.js
@@ -107,6 +107,7 @@ const config = {
             label: "Tutorial",
           },
           { to: "/blog", label: "Blog", position: "left" },
+          { to: "/markdown-page", label: "Custom page", position: "left" },
           {
             href: "https://github.com/facebook/docusaurus",
             label: "GitHub",

--- a/apps/demo/docusaurus.config.js
+++ b/apps/demo/docusaurus.config.js
@@ -85,6 +85,10 @@ const config = {
             path: "/docs/category/tutorial---basics/*",
           },
           {
+            // custom page - not docs based
+            path: "/markdown-page",
+          },
+          {
             path: "/docs/category/tutorial---basics",
           },
         ],

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "0.5.0",
+  "version": "0.5.1-rc.0",
   "private": true,
   "scripts": {
     "build": "docusaurus build",

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "build": "docusaurus build",
@@ -30,7 +30,7 @@
     "@docusaurus/core": "^2.4.0",
     "@docusaurus/preset-classic": "^2.4.0",
     "@mdx-js/react": "^1.6.22",
-    "@slashid/docusaurus-theme-slashid": "^0.4.0",
+    "@slashid/docusaurus-theme-slashid": "^0.5.0",
     "@slashid/react": "^1.18.0",
     "@slashid/slashid": "^3.18.0",
     "clsx": "^1.2.1",

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "0.5.1-rc.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "build": "docusaurus build",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.5.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0",
+  "version": "0.5.1-rc.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.1-rc.0",
+  "version": "0.5.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docusaurus-theme-slashid/README.md
+++ b/packages/docusaurus-theme-slashid/README.md
@@ -133,14 +133,15 @@ The configuration options are explained in the following section.
 
 The `docusaurus-theme-slashid` theme can be configured with the following options:
 
-| Name                        | Type            | Default     | Description                                                            |
-| --------------------------- | --------------- | ----------- | ---------------------------------------------------------------------- |
-| `slashID.orgID`             | `string`        | `null`      | The SlashID organization ID.                                           |
-| `slashID.forceLogin`        | `boolean`       | `false`     | Make login required.                                                   |
-| `slashID.baseURL`           | `boolean`       | `false`     | Base API URL for the SDK, defaults to the production environment.      |
-| `slashID.sdkURL`            | `boolean`       | `false`     | Base SDK page URL for the SDK, defaults to the production environment. |
-| `slashID.privatePaths`      | `PrivatePath[]` | `undefined` | Optional set of private paths.                                         |
-| `slashID.formConfiguration` | `object`        | `undefined` | Optional form configuration                                            |
+| Name                        | Type                  | Default     | Description                                                            |
+| --------------------------- | --------------------- | ----------- | ---------------------------------------------------------------------- |
+| `slashID.orgID`             | `string`              | `null`      | The SlashID organization ID.                                           |
+| `slashID.forceLogin`        | `boolean`             | `false`     | Make login required.                                                   |
+| `slashID.baseURL`           | `boolean`             | `false`     | Base API URL for the SDK, defaults to the production environment.      |
+| `slashID.sdkURL`            | `boolean`             | `false`     | Base SDK page URL for the SDK, defaults to the production environment. |
+| `slashID.uxMode`            | `redirect` or `modal` | `redirect`  | Behaviour when accessing a private path when unauthenticated.          |
+| `slashID.privatePaths`      | `PrivatePath[]`       | `undefined` | Optional set of private paths.                                         |
+| `slashID.formConfiguration` | `object`              | `undefined` | Optional form configuration                                            |
 
 ### Form configuration
 

--- a/packages/docusaurus-theme-slashid/package.json
+++ b/packages/docusaurus-theme-slashid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashid/docusaurus-theme-slashid",
-  "version": "0.5.0",
+  "version": "0.5.1-rc.0",
   "description": "SlashID theme for Docusaurus.",
   "keywords": [
     "login",

--- a/packages/docusaurus-theme-slashid/package.json
+++ b/packages/docusaurus-theme-slashid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashid/docusaurus-theme-slashid",
-  "version": "0.5.1-rc.0",
+  "version": "0.5.0",
   "description": "SlashID theme for Docusaurus.",
   "keywords": [
     "login",

--- a/packages/docusaurus-theme-slashid/package.json
+++ b/packages/docusaurus-theme-slashid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashid/docusaurus-theme-slashid",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "SlashID theme for Docusaurus.",
   "keywords": [
     "login",

--- a/packages/docusaurus-theme-slashid/src/domain.ts
+++ b/packages/docusaurus-theme-slashid/src/domain.ts
@@ -35,6 +35,7 @@ export interface LegacyThemeConfig {
   baseURL?: string;
   sdkURL?: string;
   privatePaths?: PrivatePath[];
+  // TODO make it configurable to show login instead of redirect
   privateRedirectPath?: string;
 }
 

--- a/packages/docusaurus-theme-slashid/src/domain.ts
+++ b/packages/docusaurus-theme-slashid/src/domain.ts
@@ -25,6 +25,8 @@ export interface ThemeConfig {
   slashID: LegacyThemeConfig | NewThemeConfig;
 }
 
+export type UXMode = "redirect" | "modal";
+
 export interface LegacyThemeConfig {
   orgID: string;
   // @deprecated use formConfiguration instead
@@ -48,6 +50,8 @@ export interface NewThemeConfig {
   forceLogin?: boolean;
   baseURL?: string;
   sdkURL?: string;
+  // behaviour when accessing a private path
+  uxMode?: UXMode;
   privatePaths?: PrivatePath[];
   privateRedirectPath?: string;
   formConfiguration?: SlashIDConfigurationProviderConfig;

--- a/packages/docusaurus-theme-slashid/src/theme/NavbarItem/index.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/NavbarItem/index.tsx
@@ -1,0 +1,40 @@
+/* ============================================================================
+ * Copyright (c) SlashID
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import React from "react";
+
+import { useSlashID } from "@slashid/react";
+import NavbarItem from "@theme-init/NavbarItem";
+
+import { shouldPathRender } from "../../domain";
+import { useSlashIDConfig } from "../hooks/useSlashIDConfig";
+
+type NavItem = {
+  to?: `/${string}`;
+};
+
+function isNavItem(item: any): item is NavItem {
+  return typeof item.to === "string";
+}
+
+export default function NavbarItemWrapper(props: any) {
+  const options = useSlashIDConfig();
+  const { user } = useSlashID();
+
+  if (
+    isNavItem(props) &&
+    !shouldPathRender(props.to, options.privatePaths, user)
+  ) {
+    return null;
+  }
+
+  return (
+    <>
+      <NavbarItem {...props} />
+    </>
+  );
+}

--- a/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
@@ -30,7 +30,7 @@ const AuthCheck: React.FC<AuthCheckProps> = ({ children }) => {
   const { user } = useSlashID();
   const { showLogin } = useContext(AuthContext);
   const isBrowser = useIsBrowser();
-  const options = useSlashIDConfig();
+  const config = useSlashIDConfig();
   const location = useLocation();
 
   // TODO figure out where the reference to window is
@@ -38,14 +38,22 @@ const AuthCheck: React.FC<AuthCheckProps> = ({ children }) => {
     return null;
   }
 
-  if (!shouldPathRender(location.pathname, options.privatePaths, user)) {
-    return <Redirect to={options.privateRedirectPath ?? ""} />;
+  // eslint-disable-next-line testing-library/render-result-naming-convention
+  const shouldRenderByPath = shouldPathRender(
+    location.pathname,
+    config.privatePaths,
+    user
+  );
+
+  if (!shouldRenderByPath && config.uxMode === "redirect") {
+    return <Redirect to={config.privateRedirectPath ?? "/"} />;
   }
 
-  const shouldShowLogin = (options.forceLogin && !user) || showLogin;
+  const shouldShowLogin =
+    (config.forceLogin && !user) || showLogin || !shouldRenderByPath;
 
   return shouldShowLogin ? (
-    <SlashID configuration={options.formConfiguration!} />
+    <SlashID configuration={config.formConfiguration!} />
   ) : (
     <>{children}</>
   );

--- a/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
@@ -7,6 +7,7 @@
 
 import React, { useContext } from "react";
 
+import { Redirect, useLocation } from "@docusaurus/router";
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import {
   SlashIDProvider,
@@ -17,6 +18,7 @@ import {
 
 import "./reset.css";
 import "./globals.css";
+import { shouldPathRender } from "../../domain";
 import { useSlashIDConfig } from "../hooks/useSlashIDConfig";
 import { AuthContext, AuthProvider } from "./auth-context";
 import { SlashID } from "./slashid";
@@ -29,22 +31,32 @@ const AuthCheck: React.FC<AuthCheckProps> = ({ children }) => {
   const { showLogin } = useContext(AuthContext);
   const isBrowser = useIsBrowser();
   const options = useSlashIDConfig();
+  const location = useLocation();
+
+  console.log(
+    "AuthCheck",
+    user,
+    showLogin,
+    options.forceLogin,
+    options.formConfiguration,
+    options.baseURL,
+    options.sdkURL,
+    options.orgID,
+    options
+  );
 
   // TODO figure out where the reference to window is
   if (!isBrowser) {
     return null;
   }
 
-  // if login is configured to be mandatory
-  if (options.forceLogin) {
-    return user ? (
-      <>{children}</>
-    ) : (
-      <SlashID configuration={options.formConfiguration!} />
-    );
+  if (!shouldPathRender(location.pathname, options.privatePaths, user)) {
+    return <Redirect to={options.privateRedirectPath ?? ""} />;
   }
 
-  return showLogin ? (
+  const shouldShowLogin = (options.forceLogin && !user) || showLogin;
+
+  return shouldShowLogin ? (
     <SlashID configuration={options.formConfiguration!} />
   ) : (
     <>{children}</>

--- a/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/Root/index.tsx
@@ -33,18 +33,6 @@ const AuthCheck: React.FC<AuthCheckProps> = ({ children }) => {
   const options = useSlashIDConfig();
   const location = useLocation();
 
-  console.log(
-    "AuthCheck",
-    user,
-    showLogin,
-    options.forceLogin,
-    options.formConfiguration,
-    options.baseURL,
-    options.sdkURL,
-    options.orgID,
-    options
-  );
-
   // TODO figure out where the reference to window is
   if (!isBrowser) {
     return null;

--- a/packages/docusaurus-theme-slashid/src/theme/hooks/useSlashIDConfig.tsx
+++ b/packages/docusaurus-theme-slashid/src/theme/hooks/useSlashIDConfig.tsx
@@ -34,6 +34,7 @@ const DEFAULT_CONFIG: NewThemeConfig = {
   forceLogin: false,
   baseURL: "https://api.slashid.com",
   sdkURL: "https://cdn.slashid.com/sdk.html",
+  uxMode: "redirect",
   privateRedirectPath: "/",
   formConfiguration: {
     storeLastHandle: true,


### PR DESCRIPTION
Apply `privatePaths` to custom pages, as well as the docs. Add the configuration option to determine the behaviour in case someone ends up on a private path.

Added the `uxMode` config option to define behaviour when an unauthenticated user accesses a private path:
- `redirect` is the default option, behaves consistent to the previous version - redirects to the path defined as `privateRedirectPath` or `"/"`
- `modal` will render the login form on top of the private page

## Testing

Released a beta version - `@slashid/docusaurus-theme-slashid@0.5.0-beta.0`
