### PR TITLE
Enabled Dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Let [Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) help keep dependencies up to date.